### PR TITLE
Return maximum amount of keys if `n` is higher than the amount of keys

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,13 +5,14 @@ module.exports = function (obj, n) {
 		throw new Error('Expected an object as the first argument');
 	}
 
-	if (n >= Object.keys(obj).length) {
-		throw new Error('Second argument must be lower than the number of keys')
+	var keys = Object.keys(obj);
+	var ret = [];
+
+	if (n >= keys.length) {
+		n = keys.length;
 	}
 
-	var keys = Object.keys(obj);
-	var n = Number(n) || 1;
-	var ret = [];
+	n = Number(n) || 1;
 
 	while (n-- && keys.length > 0) {
 		var r = Math.floor(Math.random() * keys.length);

--- a/readme.md
+++ b/readme.md
@@ -47,8 +47,6 @@ Default: `1`
 
 Quantity of returned values.
 
-*Must be lower than the amount of keys*
-
 
 ## License
 

--- a/test.js
+++ b/test.js
@@ -19,5 +19,6 @@ test('Random', function (t) {
 
 	t.assert(objectRandom(obj).length === 1);
 	t.assert(objectRandom(obj, 4).length === 4);
+	t.assert(objectRandom(obj, 24).length === 10);
 	t.assert(Array.isArray(objectRandom(obj, 8)));
 });


### PR DESCRIPTION
You don't always know how many keys there are and this way users don't have to count them.